### PR TITLE
Content search result summary

### DIFF
--- a/app/models/workarea/search/storefront/content.rb
+++ b/app/models/workarea/search/storefront/content.rb
@@ -27,7 +27,7 @@ module Workarea
         end
 
         def text
-          @text ||= ExtractContentBlockText.new(model.blocks).text
+          @text ||= model.meta_description || text_extracted_from_blocks
         end
 
         def suggestion_content
@@ -48,6 +48,12 @@ module Workarea
             !model.contentable.class.name.in?(
               Workarea.config.exclude_from_content_search_index
             )
+        end
+
+        private
+
+        def text_extracted_from_blocks
+          ExtractContentBlockText.new(model.blocks).text
         end
       end
     end

--- a/test/models/workarea/search/storefront/content_test.rb
+++ b/test/models/workarea/search/storefront/content_test.rb
@@ -22,6 +22,26 @@ module Workarea
             assert(page_content_search_model.should_be_indexed?)
           end
         end
+
+        def test_use_meta_description_for_text_when_available
+          page = create_page
+          model = Workarea::Content.for(page).tap do |content|
+            content.blocks.create!(
+              type: :html,
+              data: {
+                'html' => '<p>lorem ipsum dolor sit amet</p>'
+              }
+            )
+          end
+          content = Content.new(model)
+
+          assert_equal('lorem ipsum dolor sit amet', content.text)
+
+          model.update!(meta_description: 'foo bar baz')
+          content = Content.new(model)
+
+          assert_equal('foo bar baz', content.text)
+        end
       end
     end
   end


### PR DESCRIPTION
It's not always desirable for a content block to have it's data indexed. Any value in the `data` hash that appears more than 5 words is indexed and used as the summary during a content search. Example system test to demonstrate the issue:

```
      def test_content_search_yields_weird_results
        update_search_settings
        Content.for(create_page(name: 'Content Test')).tap do |content|
          content.blocks.create!(
            type: :hero,
            data: { asset: 'required', style: 'this is a test string'}
          )
        end
        visit storefront.search_path(q: 'content')
        assert(page.has_content?('this is a test string'))
      end
```
