### PR TITLE
Add Autocomplete to Content Search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,4 @@ gemspec
 # gem 'byebug', group: [:development, :test]
 
 gem 'workarea', github: 'workarea-commerce/workarea'
+gem 'workarea-search_autocomplete', github: 'workarea-commerce/workarea-search-autocomplete', branch: :master

--- a/app/assets/stylesheets/workarea/storefront/content_search/components/_search_autocomplete.scss
+++ b/app/assets/stylesheets/workarea/storefront/content_search/components/_search_autocomplete.scss
@@ -1,0 +1,11 @@
+/**
+ * Extensions to the search autocomplete plugin to support content
+ * results.
+ */
+
+.search-autocomplete__content {
+    @extend %list-reset;
+    text-align: left;
+}
+    .search-autocomplete__content-item {}
+        .search-autocomplete__content-link {}

--- a/app/view_models/workarea/storefront/search_autocomplete_view_model.decorator
+++ b/app/view_models/workarea/storefront/search_autocomplete_view_model.decorator
@@ -1,0 +1,17 @@
+module Workarea
+  if Plugin.installed?(:search_autocomplete)
+    decorate Storefront::SearchAutocompleteViewModel, with: :content_search do
+      def content_results
+        @content_results ||= begin
+          return [] if searches.blank?
+
+          results = Storefront::ContentSearchViewModel.wrap(response, options)
+
+          results.content.take(
+            Workarea.config.storefront_search_autocomplete_max_content
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/views/workarea/storefront/searches/_autocomplete_content.html.haml
+++ b/app/views/workarea/storefront/searches/_autocomplete_content.html.haml
@@ -1,0 +1,7 @@
+- if @autocomplete.content_results.any?
+  %ul.search-autocomplete__content
+    %span.search-autocomplete__heading
+      = t('workarea.storefront.search_autocomplete.content_heading', term: @autocomplete.searches.first)
+    - @autocomplete.content_results.each do |result|
+      %li.search-autocomplete__content-item
+        = link_to result.name, send("#{result.resource_name}_path", result), class: 'search-autocomplete__content-link'

--- a/config/initializers/appends.rb
+++ b/config/initializers/appends.rb
@@ -2,3 +2,15 @@ Workarea.append_partials(
   'storefront.above_search_results',
   'workarea/storefront/searches/search_type_toggle'
 )
+
+if Workarea::Plugin.installed?(:search_autocomplete)
+  Workarea.append_stylesheets(
+    'storefront.components',
+    'workarea/storefront/content_search/components/search_autocomplete'
+  )
+
+  Workarea.append_partials(
+    'storefront.search_autocomplete_under_searches',
+    'workarea/storefront/searches/autocomplete_content'
+  )
+end

--- a/config/initializers/configuration.rb
+++ b/config/initializers/configuration.rb
@@ -16,4 +16,8 @@ Workarea.configure do |config|
     Workarea::Search::Customization
     Workarea::Navigation::Menu
   )
+
+  if Workarea::Plugin.installed?(:search_autocomplete)
+    config.storefront_search_autocomplete_max_content = 5
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,3 +5,5 @@ en:
         product_result: product result
         content_result: content result
         content: Content
+      search_autocomplete:
+        content_heading: "Content Results: %{term}"

--- a/test/system/workarea/storefront/content_search_autocomplete_system_test.rb
+++ b/test/system/workarea/storefront/content_search_autocomplete_system_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+module Workarea
+  if Plugin.installed?(:search_autocomplete)
+    module Storefront
+      class ContentSearchAutocompleteSystemTest < Workarea::SystemTest
+        def test_content_appears_in_autocomplete
+          create_page(name: 'Content Test One')
+          create_page(name: 'Content Test Two')
+          create_page(name: 'Content Test Three')
+          create_product(name: 'Test One')
+          create_product(name: 'Test Two')
+          create_search_by_week(query_string: 'test one', searches: 5, total_results: 5)
+          create_search_by_week(query_string: 'test two', searches: 10, total_results: 5)
+
+          visit storefront.root_path
+
+          fill_in :q, with: 'te'
+
+          within '#search_autocomplete' do
+            assert_text(
+              t(
+                'workarea.storefront.search_autocomplete.content_heading',
+                term: 'test two'
+              )
+            )
+            assert_text('Content Test One')
+            assert_text('Content Test Two')
+            assert_text('Content Test Three')
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/view_models/workarea/storefront/content_search_autocomplete_view_model_test.rb
+++ b/test/view_models/workarea/storefront/content_search_autocomplete_view_model_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+module Workarea
+  if Plugin.installed?(:search_autocomplete)
+    module Storefront
+      class SearchAutocompleteViewModelTest < Workarea::TestCase
+        include TestCase::SearchIndexing
+
+        def test_content
+          query = QueryString.new('te').pretty
+          search = Storefront::SearchAutocompleteViewModel.wrap(query)
+
+          Sidekiq::Callbacks.enable do
+            create_page(name: 'Content Test One')
+            create_page(name: 'Content Test Two')
+            create_page(name: 'Content Test Three')
+            create_product(name: 'Test One')
+            create_product(name: 'Test Two')
+            create_search_by_week(
+              query_string: 'test one',
+              searches: 5,
+              total_results: 5
+            )
+            create_search_by_week(
+              query_string: 'test two',
+              searches: 10,
+              total_results: 5
+            )
+          end
+
+          refute_empty(search.content_results)
+          assert_equal(3, search.content_results.count)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Using the shiny new [workarea-search-autocomplete][] plugin, Content
Search can now provide autocomplete results for the given search term.
Content results are injected right below the common search terms, and
augments the existing autocomplete with results from pages, blog posts,
and other contentable items.

**NOTE:** This is dependent on workarea-commerce/workarea-search-autocomplete#4
for the new append point. Once that gets merged in I will update the `Gemfile` in this
repo to use the master branch and submit the PR for real.

[workarea-search-autocomplete]: https://github.com/workarea-commerce/workarea-search-autocomplete