### PR TITLE
Support Latest Version Of Search Autocomplete

### DIFF
--- a/app/assets/stylesheets/workarea/storefront/content_search/components/_search_autocomplete.scss
+++ b/app/assets/stylesheets/workarea/storefront/content_search/components/_search_autocomplete.scss
@@ -4,10 +4,18 @@
  */
 
 .search-autocomplete__content {
-    @extend %list-reset;
-    text-align: right;
+    @include respond-to($small-breakpoint) {
+        text-align: center;
+    }
+
+    @include respond-to($medium-breakpoint) {
+        text-align: right;
+    }
 }
 
+    .search-autocomplete__content-list {
+        @extend %list-reset;
+    }
     .search-autocomplete__content-item {}
 
         .search-autocomplete__content-link {}

--- a/app/views/workarea/storefront/searches/_autocomplete_content.html.haml
+++ b/app/views/workarea/storefront/searches/_autocomplete_content.html.haml
@@ -1,7 +1,8 @@
 - if @autocomplete.content_results.any?
-  %ul.search-autocomplete__content
+  .search-autocomplete__content
     %span.search-autocomplete__heading
       = t('workarea.storefront.search_autocomplete.content_heading', term: @autocomplete.searches.first)
-    - @autocomplete.content_results.each do |result|
-      %li.search-autocomplete__content-item
-        = link_to result.name, send("#{result.resource_name}_path", result), class: 'search-autocomplete__content-link'
+    %ul.search-autocomplete__content-list
+      - @autocomplete.content_results.each do |result|
+        %li.search-autocomplete__content-item
+          = link_to result.name, send("#{result.resource_name}_path", result), class: 'search-autocomplete__content-link'


### PR DESCRIPTION
Update the markup and CSS to support search autocomplete on mobile, rendering them similarly to the searches.